### PR TITLE
부루마블 모드 칸 객체 생성

### DIFF
--- a/src/shared/boardData.ts
+++ b/src/shared/boardData.ts
@@ -1,0 +1,683 @@
+export enum AREA_TYPE {
+	STARTING_POINT,
+	COUNTRY,
+	SPECIAL_AREA,
+	GOLDEN_KEY,
+	DESERT_ISLAND,
+	GET_WELFARE,
+	PAY_WELFARE,
+	SPACE_TRAVEL,
+}
+
+export class BaseArea {
+	constructor(public type: AREA_TYPE) {}
+}
+
+class GoldenKey extends BaseArea {
+	constructor(public number: number) {
+		super(AREA_TYPE.GOLDEN_KEY);
+	}
+}
+
+class TradingArea extends BaseArea {
+	constructor(
+		type: AREA_TYPE.COUNTRY | AREA_TYPE.SPECIAL_AREA,
+		public id: TradingAreaIdEnum,
+		public name: string,
+		public description: string,
+	) {
+		super(type);
+	}
+
+	get englishName() {
+		return TradingAreaIdEnum[this.id].replace('_', ' ');
+	}
+}
+
+class CountryArea extends TradingArea {
+	buildingPriceInfo: PriceInfo;
+	paymentInfo: PriceInfo;
+
+	constructor(
+		id: TradingAreaIdEnum,
+		name: string,
+		description: string,
+		buildingPriceInfo: PriceInfo,
+		paymentInfo: PriceInfo,
+	) {
+		super(AREA_TYPE.COUNTRY, id, name, description);
+		this.buildingPriceInfo = buildingPriceInfo;
+		this.paymentInfo = paymentInfo;
+	}
+}
+
+class SpecialArea extends TradingArea {
+	constructor(
+		id: TradingAreaIdEnum,
+		name: string,
+		description: string,
+		public price: number,
+		public payment: number,
+	) {
+		super(AREA_TYPE.SPECIAL_AREA, id, name, description);
+	}
+}
+
+export enum TradingAreaIdEnum {
+	TAIPEI,
+	BEIJING,
+	MANILA,
+	JEJU_ISLAND,
+	SINGAPORE,
+	CAIRO,
+	ISTANBUL,
+	ATHENES,
+	COPENHAGEN,
+	STOCKHOLM,
+	CONCORDE,
+	BERN,
+	BERLIN,
+	OTAWA,
+	BUENOSAIRES,
+	SAO_PAULO,
+	SYDNEY,
+	BUSAN,
+	HAWAII,
+	LISBON,
+	QUEEN_ELIZABETH,
+	MADRID,
+	TOKYO,
+	COLUMBIA,
+	PARIS,
+	ROME,
+	LONDON,
+	NEW_YORK,
+	SEOUL,
+}
+
+export interface PriceInfo {
+	areaPrice: number;
+	villaPrice: number;
+	buildingPrice: number;
+	hotelPrice: number;
+}
+
+export const getTradingAreaEnglishName = (areaId: TradingAreaIdEnum) =>
+	TradingAreaIdEnum[areaId].replace('_', ' ');
+
+export const countryAreaMap: Map<TradingAreaIdEnum, CountryArea> = new Map([
+	[
+		TradingAreaIdEnum.TAIPEI,
+		new CountryArea(
+			TradingAreaIdEnum.BEIJING,
+			'타이페이',
+			'타이완(대만)의 수도',
+			{
+				areaPrice: 50000,
+				villaPrice: 50000,
+				buildingPrice: 150000,
+				hotelPrice: 250000,
+			},
+			{
+				areaPrice: 2000,
+				villaPrice: 50000,
+				buildingPrice: 90000,
+				hotelPrice: 250000,
+			},
+		),
+	],
+	[
+		TradingAreaIdEnum.BEIJING,
+		new CountryArea(
+			TradingAreaIdEnum.BEIJING,
+			'베이징',
+			'중국의 수도',
+			{
+				areaPrice: 80000,
+				villaPrice: 50000,
+				buildingPrice: 150000,
+				hotelPrice: 250000,
+			},
+			{
+				areaPrice: 4000,
+				villaPrice: 50000,
+				buildingPrice: 180000,
+				hotelPrice: 450000,
+			},
+		),
+	],
+	[
+		TradingAreaIdEnum.MANILA,
+		new CountryArea(
+			TradingAreaIdEnum.MANILA,
+			'마닐라',
+			'필리핀의 수도',
+			{
+				areaPrice: 80000,
+				villaPrice: 50000,
+				buildingPrice: 150000,
+				hotelPrice: 250000,
+			},
+			{
+				areaPrice: 4000,
+				villaPrice: 50000,
+				buildingPrice: 180000,
+				hotelPrice: 250000,
+			},
+		),
+	],
+	[
+		TradingAreaIdEnum.SINGAPORE,
+		new CountryArea(
+			TradingAreaIdEnum.SINGAPORE,
+			'싱가포르',
+			'싱가포르의 수도',
+			{
+				areaPrice: 100000,
+				villaPrice: 50000,
+				buildingPrice: 150000,
+				hotelPrice: 250000,
+			},
+			{
+				areaPrice: 6000,
+				villaPrice: 50000,
+				buildingPrice: 270000,
+				hotelPrice: 550000,
+			},
+		),
+	],
+	[
+		TradingAreaIdEnum.CAIRO,
+		new CountryArea(
+			TradingAreaIdEnum.CAIRO,
+			'카이로',
+			'이집트의 수도',
+			{
+				areaPrice: 100000,
+				villaPrice: 50000,
+				buildingPrice: 150000,
+				hotelPrice: 250000,
+			},
+			{
+				areaPrice: 6000,
+				villaPrice: 50000,
+				buildingPrice: 270000,
+				hotelPrice: 550000,
+			},
+		),
+	],
+	[
+		TradingAreaIdEnum.ISTANBUL,
+		new CountryArea(
+			TradingAreaIdEnum.ISTANBUL,
+			'이스탄불',
+			'동서양의 교차로',
+			{
+				areaPrice: 100000,
+				villaPrice: 50000,
+				buildingPrice: 150000,
+				hotelPrice: 250000,
+			},
+			{
+				areaPrice: 8000,
+				villaPrice: 50000,
+				buildingPrice: 300000,
+				hotelPrice: 600000,
+			},
+		),
+	],
+	[
+		TradingAreaIdEnum.ATHENES,
+		new CountryArea(
+			TradingAreaIdEnum.ATHENES,
+			'아테네',
+			'그리스의 수도',
+			{
+				areaPrice: 140000,
+				villaPrice: 100000,
+				buildingPrice: 300000,
+				hotelPrice: 500000,
+			},
+			{
+				areaPrice: 10000,
+				villaPrice: 100000,
+				buildingPrice: 450000,
+				hotelPrice: 750000,
+			},
+		),
+	],
+	[
+		TradingAreaIdEnum.COPENHAGEN,
+		new CountryArea(
+			TradingAreaIdEnum.COPENHAGEN,
+			'코펜하겐',
+			'덴마크의 수도',
+			{
+				areaPrice: 160000,
+				villaPrice: 100000,
+				buildingPrice: 300000,
+				hotelPrice: 500000,
+			},
+			{
+				areaPrice: 12000,
+				villaPrice: 100000,
+				buildingPrice: 500000,
+				hotelPrice: 900000,
+			},
+		),
+	],
+	[
+		TradingAreaIdEnum.STOCKHOLM,
+		new CountryArea(
+			TradingAreaIdEnum.STOCKHOLM,
+			'스톡홀름',
+			'스웨덴의 수도',
+			{
+				areaPrice: 160000,
+				villaPrice: 100000,
+				buildingPrice: 300000,
+				hotelPrice: 500000,
+			},
+			{
+				areaPrice: 12000,
+				villaPrice: 100000,
+				buildingPrice: 500000,
+				hotelPrice: 900000,
+			},
+		),
+	],
+	[
+		TradingAreaIdEnum.BERN,
+		new CountryArea(
+			TradingAreaIdEnum.BERN,
+			'베른',
+			'스위스의 수도',
+			{
+				areaPrice: 180000,
+				villaPrice: 100000,
+				buildingPrice: 300000,
+				hotelPrice: 500000,
+			},
+			{
+				areaPrice: 14000,
+				villaPrice: 100000,
+				buildingPrice: 550000,
+				hotelPrice: 950000,
+			},
+		),
+	],
+	[
+		TradingAreaIdEnum.BERLIN,
+		new CountryArea(
+			TradingAreaIdEnum.BERLIN,
+			'베를린',
+			'독일의 수도',
+			{
+				areaPrice: 180000,
+				villaPrice: 100000,
+				buildingPrice: 300000,
+				hotelPrice: 500000,
+			},
+			{
+				areaPrice: 14000,
+				villaPrice: 100000,
+				buildingPrice: 550000,
+				hotelPrice: 950000,
+			},
+		),
+	],
+	[
+		TradingAreaIdEnum.OTAWA,
+		new CountryArea(
+			TradingAreaIdEnum.OTAWA,
+			'오타와',
+			'캐나다의 수도',
+			{
+				areaPrice: 200000,
+				villaPrice: 100000,
+				buildingPrice: 300000,
+				hotelPrice: 500000,
+			},
+			{
+				areaPrice: 16000,
+				villaPrice: 100000,
+				buildingPrice: 600000,
+				hotelPrice: 1000000,
+			},
+		),
+	],
+	[
+		TradingAreaIdEnum.BUENOSAIRES,
+		new CountryArea(
+			TradingAreaIdEnum.BUENOSAIRES,
+			'부에노스 아이레스',
+			'아르헨티나의 수도',
+			{
+				areaPrice: 220000,
+				villaPrice: 150000,
+				buildingPrice: 450000,
+				hotelPrice: 750000,
+			},
+			{
+				areaPrice: 10000,
+				villaPrice: 150000,
+				buildingPrice: 750000,
+				hotelPrice: 1100000,
+			},
+		),
+	],
+	[
+		TradingAreaIdEnum.SAO_PAULO,
+		new CountryArea(
+			TradingAreaIdEnum.SAO_PAULO,
+			'상파울로',
+			'브라질의 수도',
+			{
+				areaPrice: 240000,
+				villaPrice: 150000,
+				buildingPrice: 450000,
+				hotelPrice: 750000,
+			},
+			{
+				areaPrice: 20000,
+				villaPrice: 150000,
+				buildingPrice: 750000,
+				hotelPrice: 1100000,
+			},
+		),
+	],
+	[
+		TradingAreaIdEnum.SYDNEY,
+		new CountryArea(
+			TradingAreaIdEnum.SYDNEY,
+			'시드니',
+			'호주의 수도',
+			{
+				areaPrice: 240000,
+				villaPrice: 150000,
+				buildingPrice: 450000,
+				hotelPrice: 750000,
+			},
+			{
+				areaPrice: 20000,
+				villaPrice: 150000,
+				buildingPrice: 750000,
+				hotelPrice: 1100000,
+			},
+		),
+	],
+	[
+		TradingAreaIdEnum.HAWAII,
+		new CountryArea(
+			TradingAreaIdEnum.HAWAII,
+			'하와이',
+			'미국의 휴양지',
+			{
+				areaPrice: 260000,
+				villaPrice: 150000,
+				buildingPrice: 450000,
+				hotelPrice: 750000,
+			},
+			{
+				areaPrice: 22000,
+				villaPrice: 150000,
+				buildingPrice: 800000,
+				hotelPrice: 1150000,
+			},
+		),
+	],
+	[
+		TradingAreaIdEnum.LISBON,
+		new CountryArea(
+			TradingAreaIdEnum.LISBON,
+			'리스본',
+			'포르투갈의 수도',
+			{
+				areaPrice: 260000,
+				villaPrice: 150000,
+				buildingPrice: 450000,
+				hotelPrice: 750000,
+			},
+			{
+				areaPrice: 24000,
+				villaPrice: 150000,
+				buildingPrice: 850000,
+				hotelPrice: 1200000,
+			},
+		),
+	],
+	[
+		TradingAreaIdEnum.MADRID,
+		new CountryArea(
+			TradingAreaIdEnum.MADRID,
+			'마드리드',
+			'스페인의 수도',
+			{
+				areaPrice: 280000,
+				villaPrice: 150000,
+				buildingPrice: 450000,
+				hotelPrice: 750000,
+			},
+			{
+				areaPrice: 24000,
+				villaPrice: 150000,
+				buildingPrice: 850000,
+				hotelPrice: 1200000,
+			},
+		),
+	],
+	[
+		TradingAreaIdEnum.TOKYO,
+		new CountryArea(
+			TradingAreaIdEnum.TOKYO,
+			'도쿄',
+			'일본의 수도',
+			{
+				areaPrice: 300000,
+				villaPrice: 200000,
+				buildingPrice: 600000,
+				hotelPrice: 1000000,
+			},
+			{
+				areaPrice: 26000,
+				villaPrice: 200000,
+				buildingPrice: 900000,
+				hotelPrice: 1270000,
+			},
+		),
+	],
+	[
+		TradingAreaIdEnum.PARIS,
+		new CountryArea(
+			TradingAreaIdEnum.PARIS,
+			'파리',
+			'프랑스의 수도',
+			{
+				areaPrice: 320000,
+				villaPrice: 200000,
+				buildingPrice: 600000,
+				hotelPrice: 1000000,
+			},
+			{
+				areaPrice: 28000,
+				villaPrice: 200000,
+				buildingPrice: 1000000,
+				hotelPrice: 1270000,
+			},
+		),
+	],
+	[
+		TradingAreaIdEnum.ROME,
+		new CountryArea(
+			TradingAreaIdEnum.ROME,
+			'로마',
+			'이탈리아의 수도',
+			{
+				areaPrice: 320000,
+				villaPrice: 200000,
+				buildingPrice: 600000,
+				hotelPrice: 1000000,
+			},
+			{
+				areaPrice: 28000,
+				villaPrice: 200000,
+				buildingPrice: 1000000,
+				hotelPrice: 1400000,
+			},
+		),
+	],
+	[
+		TradingAreaIdEnum.LONDON,
+		new CountryArea(
+			TradingAreaIdEnum.LONDON,
+			'런던',
+			'영국의 수도',
+			{
+				areaPrice: 350000,
+				villaPrice: 200000,
+				buildingPrice: 600000,
+				hotelPrice: 1000000,
+			},
+			{
+				areaPrice: 35000,
+				villaPrice: 200000,
+				buildingPrice: 1100000,
+				hotelPrice: 1500000,
+			},
+		),
+	],
+	[
+		TradingAreaIdEnum.NEW_YORK,
+		new CountryArea(
+			TradingAreaIdEnum.NEW_YORK,
+			'뉴욕',
+			'미국 최대의 도시',
+			{
+				areaPrice: 350000,
+				villaPrice: 200000,
+				buildingPrice: 600000,
+				hotelPrice: 1000000,
+			},
+			{
+				areaPrice: 35000,
+				villaPrice: 200000,
+				buildingPrice: 1100000,
+				hotelPrice: 1500000,
+			},
+		),
+	],
+]);
+
+export const specialAreaMap: Map<TradingAreaIdEnum, SpecialArea> = new Map([
+	[
+		TradingAreaIdEnum.JEJU_ISLAND,
+		new SpecialArea(
+			TradingAreaIdEnum.JEJU_ISLAND,
+			'제주',
+			'대한민국의 휴양지',
+			200000,
+			300000,
+		),
+	],
+	[
+		TradingAreaIdEnum.CONCORDE,
+		new SpecialArea(
+			TradingAreaIdEnum.CONCORDE,
+			'콩코드여객기',
+			'초음속여객기',
+			200000,
+			300000,
+		),
+	],
+	[
+		TradingAreaIdEnum.BUSAN,
+		new SpecialArea(
+			TradingAreaIdEnum.BUSAN,
+			'부산',
+			'대한민국의 제1의 항구도시',
+			500000,
+			600000,
+		),
+	],
+	[
+		TradingAreaIdEnum.QUEEN_ELIZABETH,
+		new SpecialArea(
+			TradingAreaIdEnum.QUEEN_ELIZABETH,
+			'퀸 엘리자베스호',
+			'호화 여객선',
+			300000,
+			250000,
+		),
+	],
+	[
+		TradingAreaIdEnum.COLUMBIA,
+		new SpecialArea(
+			TradingAreaIdEnum.COLUMBIA,
+			'컬럼비아호',
+			'유인 우주 왕복선',
+			450000,
+			400000,
+		),
+	],
+	[
+		TradingAreaIdEnum.SEOUL,
+		new SpecialArea(
+			TradingAreaIdEnum.SEOUL,
+			'서울',
+			'대한민국의 수도',
+			1000000,
+			2000000,
+		),
+	],
+]);
+
+export const boardMatrix: BaseArea[][] = [
+	[
+		new BaseArea(AREA_TYPE.STARTING_POINT),
+		countryAreaMap.get(TradingAreaIdEnum.TAIPEI) as CountryArea,
+		new GoldenKey(1),
+		countryAreaMap.get(TradingAreaIdEnum.BEIJING) as CountryArea,
+		countryAreaMap.get(TradingAreaIdEnum.MANILA) as CountryArea,
+		specialAreaMap.get(TradingAreaIdEnum.JEJU_ISLAND) as SpecialArea,
+		countryAreaMap.get(TradingAreaIdEnum.SINGAPORE) as CountryArea,
+		new GoldenKey(2),
+		countryAreaMap.get(TradingAreaIdEnum.CAIRO) as CountryArea,
+		countryAreaMap.get(TradingAreaIdEnum.ISTANBUL) as CountryArea,
+	],
+	[
+		new BaseArea(AREA_TYPE.DESERT_ISLAND),
+		countryAreaMap.get(TradingAreaIdEnum.ATHENES) as CountryArea,
+		new GoldenKey(3),
+		countryAreaMap.get(TradingAreaIdEnum.COPENHAGEN) as CountryArea,
+		countryAreaMap.get(TradingAreaIdEnum.STOCKHOLM) as CountryArea,
+		specialAreaMap.get(TradingAreaIdEnum.CONCORDE) as SpecialArea,
+		countryAreaMap.get(TradingAreaIdEnum.BERN) as CountryArea,
+		new GoldenKey(4),
+		countryAreaMap.get(TradingAreaIdEnum.BERLIN) as CountryArea,
+		countryAreaMap.get(TradingAreaIdEnum.OTAWA) as CountryArea,
+	],
+	[
+		new BaseArea(AREA_TYPE.GET_WELFARE),
+		countryAreaMap.get(TradingAreaIdEnum.BUENOSAIRES) as CountryArea,
+		new GoldenKey(5),
+		countryAreaMap.get(TradingAreaIdEnum.SAO_PAULO) as CountryArea,
+		countryAreaMap.get(TradingAreaIdEnum.SYDNEY) as CountryArea,
+		specialAreaMap.get(TradingAreaIdEnum.BUSAN) as SpecialArea,
+		countryAreaMap.get(TradingAreaIdEnum.HAWAII) as CountryArea,
+		countryAreaMap.get(TradingAreaIdEnum.LISBON) as CountryArea,
+		specialAreaMap.get(TradingAreaIdEnum.QUEEN_ELIZABETH) as SpecialArea,
+		countryAreaMap.get(TradingAreaIdEnum.MADRID) as CountryArea,
+	],
+	[
+		new BaseArea(AREA_TYPE.SPACE_TRAVEL),
+		countryAreaMap.get(TradingAreaIdEnum.TOKYO) as CountryArea,
+		specialAreaMap.get(TradingAreaIdEnum.COLUMBIA) as SpecialArea,
+		countryAreaMap.get(TradingAreaIdEnum.PARIS) as CountryArea,
+		countryAreaMap.get(TradingAreaIdEnum.ROME) as CountryArea,
+		new GoldenKey(6),
+		countryAreaMap.get(TradingAreaIdEnum.LONDON) as CountryArea,
+		countryAreaMap.get(TradingAreaIdEnum.NEW_YORK) as CountryArea,
+		new BaseArea(AREA_TYPE.GET_WELFARE),
+		specialAreaMap.get(TradingAreaIdEnum.SEOUL) as SpecialArea,
+	],
+];

--- a/src/shared/boardData.ts
+++ b/src/shared/boardData.ts
@@ -1,4 +1,4 @@
-export enum AREA_TYPE {
+export enum AreaType {
 	STARTING_POINT,
 	COUNTRY,
 	SPECIAL_AREA,
@@ -10,18 +10,18 @@ export enum AREA_TYPE {
 }
 
 export class BaseArea {
-	constructor(public type: AREA_TYPE) {}
+	constructor(public type: AreaType) {}
 }
 
-class GoldenKey extends BaseArea {
+export class GoldenKey extends BaseArea {
 	constructor(public number: number) {
-		super(AREA_TYPE.GOLDEN_KEY);
+		super(AreaType.GOLDEN_KEY);
 	}
 }
 
-class TradingArea extends BaseArea {
+export class TradingArea extends BaseArea {
 	constructor(
-		type: AREA_TYPE.COUNTRY | AREA_TYPE.SPECIAL_AREA,
+		type: AreaType.COUNTRY | AreaType.SPECIAL_AREA,
 		public id: TradingAreaIdEnum,
 		public name: string,
 		public description: string,
@@ -34,7 +34,7 @@ class TradingArea extends BaseArea {
 	}
 }
 
-class CountryArea extends TradingArea {
+export class CityArea extends TradingArea {
 	buildingPriceInfo: PriceInfo;
 	paymentInfo: PriceInfo;
 
@@ -45,13 +45,13 @@ class CountryArea extends TradingArea {
 		buildingPriceInfo: PriceInfo,
 		paymentInfo: PriceInfo,
 	) {
-		super(AREA_TYPE.COUNTRY, id, name, description);
+		super(AreaType.COUNTRY, id, name, description);
 		this.buildingPriceInfo = buildingPriceInfo;
 		this.paymentInfo = paymentInfo;
 	}
 }
 
-class SpecialArea extends TradingArea {
+export class SpecialArea extends TradingArea {
 	constructor(
 		id: TradingAreaIdEnum,
 		name: string,
@@ -59,7 +59,7 @@ class SpecialArea extends TradingArea {
 		public price: number,
 		public payment: number,
 	) {
-		super(AREA_TYPE.SPECIAL_AREA, id, name, description);
+		super(AreaType.SPECIAL_AREA, id, name, description);
 	}
 }
 
@@ -105,10 +105,10 @@ export interface PriceInfo {
 export const getTradingAreaEnglishName = (areaId: TradingAreaIdEnum) =>
 	TradingAreaIdEnum[areaId].replace('_', ' ');
 
-export const countryAreaMap: Map<TradingAreaIdEnum, CountryArea> = new Map([
+export const cityAreaMap: Map<TradingAreaIdEnum, CityArea> = new Map([
 	[
 		TradingAreaIdEnum.TAIPEI,
-		new CountryArea(
+		new CityArea(
 			TradingAreaIdEnum.BEIJING,
 			'타이페이',
 			'타이완(대만)의 수도',
@@ -128,7 +128,7 @@ export const countryAreaMap: Map<TradingAreaIdEnum, CountryArea> = new Map([
 	],
 	[
 		TradingAreaIdEnum.BEIJING,
-		new CountryArea(
+		new CityArea(
 			TradingAreaIdEnum.BEIJING,
 			'베이징',
 			'중국의 수도',
@@ -148,7 +148,7 @@ export const countryAreaMap: Map<TradingAreaIdEnum, CountryArea> = new Map([
 	],
 	[
 		TradingAreaIdEnum.MANILA,
-		new CountryArea(
+		new CityArea(
 			TradingAreaIdEnum.MANILA,
 			'마닐라',
 			'필리핀의 수도',
@@ -168,7 +168,7 @@ export const countryAreaMap: Map<TradingAreaIdEnum, CountryArea> = new Map([
 	],
 	[
 		TradingAreaIdEnum.SINGAPORE,
-		new CountryArea(
+		new CityArea(
 			TradingAreaIdEnum.SINGAPORE,
 			'싱가포르',
 			'싱가포르의 수도',
@@ -188,7 +188,7 @@ export const countryAreaMap: Map<TradingAreaIdEnum, CountryArea> = new Map([
 	],
 	[
 		TradingAreaIdEnum.CAIRO,
-		new CountryArea(
+		new CityArea(
 			TradingAreaIdEnum.CAIRO,
 			'카이로',
 			'이집트의 수도',
@@ -208,7 +208,7 @@ export const countryAreaMap: Map<TradingAreaIdEnum, CountryArea> = new Map([
 	],
 	[
 		TradingAreaIdEnum.ISTANBUL,
-		new CountryArea(
+		new CityArea(
 			TradingAreaIdEnum.ISTANBUL,
 			'이스탄불',
 			'동서양의 교차로',
@@ -228,7 +228,7 @@ export const countryAreaMap: Map<TradingAreaIdEnum, CountryArea> = new Map([
 	],
 	[
 		TradingAreaIdEnum.ATHENES,
-		new CountryArea(
+		new CityArea(
 			TradingAreaIdEnum.ATHENES,
 			'아테네',
 			'그리스의 수도',
@@ -248,7 +248,7 @@ export const countryAreaMap: Map<TradingAreaIdEnum, CountryArea> = new Map([
 	],
 	[
 		TradingAreaIdEnum.COPENHAGEN,
-		new CountryArea(
+		new CityArea(
 			TradingAreaIdEnum.COPENHAGEN,
 			'코펜하겐',
 			'덴마크의 수도',
@@ -268,7 +268,7 @@ export const countryAreaMap: Map<TradingAreaIdEnum, CountryArea> = new Map([
 	],
 	[
 		TradingAreaIdEnum.STOCKHOLM,
-		new CountryArea(
+		new CityArea(
 			TradingAreaIdEnum.STOCKHOLM,
 			'스톡홀름',
 			'스웨덴의 수도',
@@ -288,7 +288,7 @@ export const countryAreaMap: Map<TradingAreaIdEnum, CountryArea> = new Map([
 	],
 	[
 		TradingAreaIdEnum.BERN,
-		new CountryArea(
+		new CityArea(
 			TradingAreaIdEnum.BERN,
 			'베른',
 			'스위스의 수도',
@@ -308,7 +308,7 @@ export const countryAreaMap: Map<TradingAreaIdEnum, CountryArea> = new Map([
 	],
 	[
 		TradingAreaIdEnum.BERLIN,
-		new CountryArea(
+		new CityArea(
 			TradingAreaIdEnum.BERLIN,
 			'베를린',
 			'독일의 수도',
@@ -328,7 +328,7 @@ export const countryAreaMap: Map<TradingAreaIdEnum, CountryArea> = new Map([
 	],
 	[
 		TradingAreaIdEnum.OTAWA,
-		new CountryArea(
+		new CityArea(
 			TradingAreaIdEnum.OTAWA,
 			'오타와',
 			'캐나다의 수도',
@@ -348,7 +348,7 @@ export const countryAreaMap: Map<TradingAreaIdEnum, CountryArea> = new Map([
 	],
 	[
 		TradingAreaIdEnum.BUENOSAIRES,
-		new CountryArea(
+		new CityArea(
 			TradingAreaIdEnum.BUENOSAIRES,
 			'부에노스 아이레스',
 			'아르헨티나의 수도',
@@ -368,7 +368,7 @@ export const countryAreaMap: Map<TradingAreaIdEnum, CountryArea> = new Map([
 	],
 	[
 		TradingAreaIdEnum.SAO_PAULO,
-		new CountryArea(
+		new CityArea(
 			TradingAreaIdEnum.SAO_PAULO,
 			'상파울로',
 			'브라질의 수도',
@@ -388,7 +388,7 @@ export const countryAreaMap: Map<TradingAreaIdEnum, CountryArea> = new Map([
 	],
 	[
 		TradingAreaIdEnum.SYDNEY,
-		new CountryArea(
+		new CityArea(
 			TradingAreaIdEnum.SYDNEY,
 			'시드니',
 			'호주의 수도',
@@ -408,7 +408,7 @@ export const countryAreaMap: Map<TradingAreaIdEnum, CountryArea> = new Map([
 	],
 	[
 		TradingAreaIdEnum.HAWAII,
-		new CountryArea(
+		new CityArea(
 			TradingAreaIdEnum.HAWAII,
 			'하와이',
 			'미국의 휴양지',
@@ -428,7 +428,7 @@ export const countryAreaMap: Map<TradingAreaIdEnum, CountryArea> = new Map([
 	],
 	[
 		TradingAreaIdEnum.LISBON,
-		new CountryArea(
+		new CityArea(
 			TradingAreaIdEnum.LISBON,
 			'리스본',
 			'포르투갈의 수도',
@@ -448,7 +448,7 @@ export const countryAreaMap: Map<TradingAreaIdEnum, CountryArea> = new Map([
 	],
 	[
 		TradingAreaIdEnum.MADRID,
-		new CountryArea(
+		new CityArea(
 			TradingAreaIdEnum.MADRID,
 			'마드리드',
 			'스페인의 수도',
@@ -468,7 +468,7 @@ export const countryAreaMap: Map<TradingAreaIdEnum, CountryArea> = new Map([
 	],
 	[
 		TradingAreaIdEnum.TOKYO,
-		new CountryArea(
+		new CityArea(
 			TradingAreaIdEnum.TOKYO,
 			'도쿄',
 			'일본의 수도',
@@ -488,7 +488,7 @@ export const countryAreaMap: Map<TradingAreaIdEnum, CountryArea> = new Map([
 	],
 	[
 		TradingAreaIdEnum.PARIS,
-		new CountryArea(
+		new CityArea(
 			TradingAreaIdEnum.PARIS,
 			'파리',
 			'프랑스의 수도',
@@ -508,7 +508,7 @@ export const countryAreaMap: Map<TradingAreaIdEnum, CountryArea> = new Map([
 	],
 	[
 		TradingAreaIdEnum.ROME,
-		new CountryArea(
+		new CityArea(
 			TradingAreaIdEnum.ROME,
 			'로마',
 			'이탈리아의 수도',
@@ -528,7 +528,7 @@ export const countryAreaMap: Map<TradingAreaIdEnum, CountryArea> = new Map([
 	],
 	[
 		TradingAreaIdEnum.LONDON,
-		new CountryArea(
+		new CityArea(
 			TradingAreaIdEnum.LONDON,
 			'런던',
 			'영국의 수도',
@@ -548,7 +548,7 @@ export const countryAreaMap: Map<TradingAreaIdEnum, CountryArea> = new Map([
 	],
 	[
 		TradingAreaIdEnum.NEW_YORK,
-		new CountryArea(
+		new CityArea(
 			TradingAreaIdEnum.NEW_YORK,
 			'뉴욕',
 			'미국 최대의 도시',
@@ -633,51 +633,51 @@ export const specialAreaMap: Map<TradingAreaIdEnum, SpecialArea> = new Map([
 
 export const boardMatrix: BaseArea[][] = [
 	[
-		new BaseArea(AREA_TYPE.STARTING_POINT),
-		countryAreaMap.get(TradingAreaIdEnum.TAIPEI) as CountryArea,
+		new BaseArea(AreaType.STARTING_POINT),
+		cityAreaMap.get(TradingAreaIdEnum.TAIPEI) as CityArea,
 		new GoldenKey(1),
-		countryAreaMap.get(TradingAreaIdEnum.BEIJING) as CountryArea,
-		countryAreaMap.get(TradingAreaIdEnum.MANILA) as CountryArea,
+		cityAreaMap.get(TradingAreaIdEnum.BEIJING) as CityArea,
+		cityAreaMap.get(TradingAreaIdEnum.MANILA) as CityArea,
 		specialAreaMap.get(TradingAreaIdEnum.JEJU_ISLAND) as SpecialArea,
-		countryAreaMap.get(TradingAreaIdEnum.SINGAPORE) as CountryArea,
+		cityAreaMap.get(TradingAreaIdEnum.SINGAPORE) as CityArea,
 		new GoldenKey(2),
-		countryAreaMap.get(TradingAreaIdEnum.CAIRO) as CountryArea,
-		countryAreaMap.get(TradingAreaIdEnum.ISTANBUL) as CountryArea,
+		cityAreaMap.get(TradingAreaIdEnum.CAIRO) as CityArea,
+		cityAreaMap.get(TradingAreaIdEnum.ISTANBUL) as CityArea,
 	],
 	[
-		new BaseArea(AREA_TYPE.DESERT_ISLAND),
-		countryAreaMap.get(TradingAreaIdEnum.ATHENES) as CountryArea,
+		new BaseArea(AreaType.DESERT_ISLAND),
+		cityAreaMap.get(TradingAreaIdEnum.ATHENES) as CityArea,
 		new GoldenKey(3),
-		countryAreaMap.get(TradingAreaIdEnum.COPENHAGEN) as CountryArea,
-		countryAreaMap.get(TradingAreaIdEnum.STOCKHOLM) as CountryArea,
+		cityAreaMap.get(TradingAreaIdEnum.COPENHAGEN) as CityArea,
+		cityAreaMap.get(TradingAreaIdEnum.STOCKHOLM) as CityArea,
 		specialAreaMap.get(TradingAreaIdEnum.CONCORDE) as SpecialArea,
-		countryAreaMap.get(TradingAreaIdEnum.BERN) as CountryArea,
+		cityAreaMap.get(TradingAreaIdEnum.BERN) as CityArea,
 		new GoldenKey(4),
-		countryAreaMap.get(TradingAreaIdEnum.BERLIN) as CountryArea,
-		countryAreaMap.get(TradingAreaIdEnum.OTAWA) as CountryArea,
+		cityAreaMap.get(TradingAreaIdEnum.BERLIN) as CityArea,
+		cityAreaMap.get(TradingAreaIdEnum.OTAWA) as CityArea,
 	],
 	[
-		new BaseArea(AREA_TYPE.GET_WELFARE),
-		countryAreaMap.get(TradingAreaIdEnum.BUENOSAIRES) as CountryArea,
+		new BaseArea(AreaType.GET_WELFARE),
+		cityAreaMap.get(TradingAreaIdEnum.BUENOSAIRES) as CityArea,
 		new GoldenKey(5),
-		countryAreaMap.get(TradingAreaIdEnum.SAO_PAULO) as CountryArea,
-		countryAreaMap.get(TradingAreaIdEnum.SYDNEY) as CountryArea,
+		cityAreaMap.get(TradingAreaIdEnum.SAO_PAULO) as CityArea,
+		cityAreaMap.get(TradingAreaIdEnum.SYDNEY) as CityArea,
 		specialAreaMap.get(TradingAreaIdEnum.BUSAN) as SpecialArea,
-		countryAreaMap.get(TradingAreaIdEnum.HAWAII) as CountryArea,
-		countryAreaMap.get(TradingAreaIdEnum.LISBON) as CountryArea,
+		cityAreaMap.get(TradingAreaIdEnum.HAWAII) as CityArea,
+		cityAreaMap.get(TradingAreaIdEnum.LISBON) as CityArea,
 		specialAreaMap.get(TradingAreaIdEnum.QUEEN_ELIZABETH) as SpecialArea,
-		countryAreaMap.get(TradingAreaIdEnum.MADRID) as CountryArea,
+		cityAreaMap.get(TradingAreaIdEnum.MADRID) as CityArea,
 	],
 	[
-		new BaseArea(AREA_TYPE.SPACE_TRAVEL),
-		countryAreaMap.get(TradingAreaIdEnum.TOKYO) as CountryArea,
+		new BaseArea(AreaType.SPACE_TRAVEL),
+		cityAreaMap.get(TradingAreaIdEnum.TOKYO) as CityArea,
 		specialAreaMap.get(TradingAreaIdEnum.COLUMBIA) as SpecialArea,
-		countryAreaMap.get(TradingAreaIdEnum.PARIS) as CountryArea,
-		countryAreaMap.get(TradingAreaIdEnum.ROME) as CountryArea,
+		cityAreaMap.get(TradingAreaIdEnum.PARIS) as CityArea,
+		cityAreaMap.get(TradingAreaIdEnum.ROME) as CityArea,
 		new GoldenKey(6),
-		countryAreaMap.get(TradingAreaIdEnum.LONDON) as CountryArea,
-		countryAreaMap.get(TradingAreaIdEnum.NEW_YORK) as CountryArea,
-		new BaseArea(AREA_TYPE.GET_WELFARE),
+		cityAreaMap.get(TradingAreaIdEnum.LONDON) as CityArea,
+		cityAreaMap.get(TradingAreaIdEnum.NEW_YORK) as CityArea,
+		new BaseArea(AreaType.GET_WELFARE),
 		specialAreaMap.get(TradingAreaIdEnum.SEOUL) as SpecialArea,
 	],
 ];

--- a/src/shared/boardData.ts
+++ b/src/shared/boardData.ts
@@ -1,4 +1,4 @@
-export enum AreaType {
+export enum TileType {
 	STARTING_POINT,
 	COUNTRY,
 	SPECIAL_AREA,
@@ -9,19 +9,19 @@ export enum AreaType {
 	SPACE_TRAVEL,
 }
 
-export class BaseArea {
-	constructor(public type: AreaType) {}
+export class BaseTile {
+	constructor(public type: TileType) {}
 }
 
-export class GoldenKey extends BaseArea {
+export class GoldenKey extends BaseTile {
 	constructor(public number: number) {
-		super(AreaType.GOLDEN_KEY);
+		super(TileType.GOLDEN_KEY);
 	}
 }
 
-export class TradingArea extends BaseArea {
+export class TradingArea extends BaseTile {
 	constructor(
-		type: AreaType.COUNTRY | AreaType.SPECIAL_AREA,
+		type: TileType.COUNTRY | TileType.SPECIAL_AREA,
 		public id: TradingAreaIdEnum,
 		public name: string,
 		public description: string,
@@ -45,7 +45,7 @@ export class CityArea extends TradingArea {
 		buildingPriceInfo: PriceInfo,
 		paymentInfo: PriceInfo,
 	) {
-		super(AreaType.COUNTRY, id, name, description);
+		super(TileType.COUNTRY, id, name, description);
 		this.buildingPriceInfo = buildingPriceInfo;
 		this.paymentInfo = paymentInfo;
 	}
@@ -59,7 +59,7 @@ export class SpecialArea extends TradingArea {
 		public price: number,
 		public payment: number,
 	) {
-		super(AreaType.SPECIAL_AREA, id, name, description);
+		super(TileType.SPECIAL_AREA, id, name, description);
 	}
 }
 
@@ -631,9 +631,9 @@ export const specialAreaMap: Map<TradingAreaIdEnum, SpecialArea> = new Map([
 	],
 ]);
 
-export const boardMatrix: BaseArea[][] = [
+export const boardMatrix: BaseTile[][] = [
 	[
-		new BaseArea(AreaType.STARTING_POINT),
+		new BaseTile(TileType.STARTING_POINT),
 		cityAreaMap.get(TradingAreaIdEnum.TAIPEI) as CityArea,
 		new GoldenKey(1),
 		cityAreaMap.get(TradingAreaIdEnum.BEIJING) as CityArea,
@@ -645,7 +645,7 @@ export const boardMatrix: BaseArea[][] = [
 		cityAreaMap.get(TradingAreaIdEnum.ISTANBUL) as CityArea,
 	],
 	[
-		new BaseArea(AreaType.DESERT_ISLAND),
+		new BaseTile(TileType.DESERT_ISLAND),
 		cityAreaMap.get(TradingAreaIdEnum.ATHENES) as CityArea,
 		new GoldenKey(3),
 		cityAreaMap.get(TradingAreaIdEnum.COPENHAGEN) as CityArea,
@@ -657,7 +657,7 @@ export const boardMatrix: BaseArea[][] = [
 		cityAreaMap.get(TradingAreaIdEnum.OTAWA) as CityArea,
 	],
 	[
-		new BaseArea(AreaType.GET_WELFARE),
+		new BaseTile(TileType.GET_WELFARE),
 		cityAreaMap.get(TradingAreaIdEnum.BUENOSAIRES) as CityArea,
 		new GoldenKey(5),
 		cityAreaMap.get(TradingAreaIdEnum.SAO_PAULO) as CityArea,
@@ -669,7 +669,7 @@ export const boardMatrix: BaseArea[][] = [
 		cityAreaMap.get(TradingAreaIdEnum.MADRID) as CityArea,
 	],
 	[
-		new BaseArea(AreaType.SPACE_TRAVEL),
+		new BaseTile(TileType.SPACE_TRAVEL),
 		cityAreaMap.get(TradingAreaIdEnum.TOKYO) as CityArea,
 		specialAreaMap.get(TradingAreaIdEnum.COLUMBIA) as SpecialArea,
 		cityAreaMap.get(TradingAreaIdEnum.PARIS) as CityArea,
@@ -677,7 +677,7 @@ export const boardMatrix: BaseArea[][] = [
 		new GoldenKey(6),
 		cityAreaMap.get(TradingAreaIdEnum.LONDON) as CityArea,
 		cityAreaMap.get(TradingAreaIdEnum.NEW_YORK) as CityArea,
-		new BaseArea(AreaType.GET_WELFARE),
+		new BaseTile(TileType.GET_WELFARE),
 		specialAreaMap.get(TradingAreaIdEnum.SEOUL) as SpecialArea,
 	],
 ];

--- a/src/shared/boardData.ts
+++ b/src/shared/boardData.ts
@@ -19,10 +19,10 @@ export class GoldenKey extends BaseTile {
 	}
 }
 
-export class TradingArea extends BaseTile {
+export class TradableArea extends BaseTile {
 	constructor(
 		type: TileType.COUNTRY | TileType.SPECIAL_AREA,
-		public id: TradingAreaIdEnum,
+		public id: TradableAreaIdEnum,
 		public name: string,
 		public description: string,
 	) {
@@ -30,16 +30,16 @@ export class TradingArea extends BaseTile {
 	}
 
 	get englishName() {
-		return TradingAreaIdEnum[this.id].replace('_', ' ');
+		return TradableAreaIdEnum[this.id].replace('_', ' ');
 	}
 }
 
-export class CityArea extends TradingArea {
+export class CityArea extends TradableArea {
 	buildingPriceInfo: PriceInfo;
 	paymentInfo: PriceInfo;
 
 	constructor(
-		id: TradingAreaIdEnum,
+		id: TradableAreaIdEnum,
 		name: string,
 		description: string,
 		buildingPriceInfo: PriceInfo,
@@ -51,9 +51,9 @@ export class CityArea extends TradingArea {
 	}
 }
 
-export class SpecialArea extends TradingArea {
+export class SpecialArea extends TradableArea {
 	constructor(
-		id: TradingAreaIdEnum,
+		id: TradableAreaIdEnum,
 		name: string,
 		description: string,
 		public price: number,
@@ -63,7 +63,7 @@ export class SpecialArea extends TradingArea {
 	}
 }
 
-export enum TradingAreaIdEnum {
+export enum TradableAreaIdEnum {
 	TAIPEI,
 	BEIJING,
 	MANILA,
@@ -102,14 +102,14 @@ export interface PriceInfo {
 	hotelPrice: number;
 }
 
-export const getTradingAreaEnglishName = (areaId: TradingAreaIdEnum) =>
-	TradingAreaIdEnum[areaId].replace('_', ' ');
+export const getTradableAreaEnglishName = (areaId: TradableAreaIdEnum) =>
+	TradableAreaIdEnum[areaId].replace('_', ' ');
 
-export const cityAreaMap: Map<TradingAreaIdEnum, CityArea> = new Map([
+export const cityAreaMap: Map<TradableAreaIdEnum, CityArea> = new Map([
 	[
-		TradingAreaIdEnum.TAIPEI,
+		TradableAreaIdEnum.TAIPEI,
 		new CityArea(
-			TradingAreaIdEnum.BEIJING,
+			TradableAreaIdEnum.BEIJING,
 			'타이페이',
 			'타이완(대만)의 수도',
 			{
@@ -127,9 +127,9 @@ export const cityAreaMap: Map<TradingAreaIdEnum, CityArea> = new Map([
 		),
 	],
 	[
-		TradingAreaIdEnum.BEIJING,
+		TradableAreaIdEnum.BEIJING,
 		new CityArea(
-			TradingAreaIdEnum.BEIJING,
+			TradableAreaIdEnum.BEIJING,
 			'베이징',
 			'중국의 수도',
 			{
@@ -147,9 +147,9 @@ export const cityAreaMap: Map<TradingAreaIdEnum, CityArea> = new Map([
 		),
 	],
 	[
-		TradingAreaIdEnum.MANILA,
+		TradableAreaIdEnum.MANILA,
 		new CityArea(
-			TradingAreaIdEnum.MANILA,
+			TradableAreaIdEnum.MANILA,
 			'마닐라',
 			'필리핀의 수도',
 			{
@@ -167,9 +167,9 @@ export const cityAreaMap: Map<TradingAreaIdEnum, CityArea> = new Map([
 		),
 	],
 	[
-		TradingAreaIdEnum.SINGAPORE,
+		TradableAreaIdEnum.SINGAPORE,
 		new CityArea(
-			TradingAreaIdEnum.SINGAPORE,
+			TradableAreaIdEnum.SINGAPORE,
 			'싱가포르',
 			'싱가포르의 수도',
 			{
@@ -187,9 +187,9 @@ export const cityAreaMap: Map<TradingAreaIdEnum, CityArea> = new Map([
 		),
 	],
 	[
-		TradingAreaIdEnum.CAIRO,
+		TradableAreaIdEnum.CAIRO,
 		new CityArea(
-			TradingAreaIdEnum.CAIRO,
+			TradableAreaIdEnum.CAIRO,
 			'카이로',
 			'이집트의 수도',
 			{
@@ -207,9 +207,9 @@ export const cityAreaMap: Map<TradingAreaIdEnum, CityArea> = new Map([
 		),
 	],
 	[
-		TradingAreaIdEnum.ISTANBUL,
+		TradableAreaIdEnum.ISTANBUL,
 		new CityArea(
-			TradingAreaIdEnum.ISTANBUL,
+			TradableAreaIdEnum.ISTANBUL,
 			'이스탄불',
 			'동서양의 교차로',
 			{
@@ -227,9 +227,9 @@ export const cityAreaMap: Map<TradingAreaIdEnum, CityArea> = new Map([
 		),
 	],
 	[
-		TradingAreaIdEnum.ATHENES,
+		TradableAreaIdEnum.ATHENES,
 		new CityArea(
-			TradingAreaIdEnum.ATHENES,
+			TradableAreaIdEnum.ATHENES,
 			'아테네',
 			'그리스의 수도',
 			{
@@ -247,9 +247,9 @@ export const cityAreaMap: Map<TradingAreaIdEnum, CityArea> = new Map([
 		),
 	],
 	[
-		TradingAreaIdEnum.COPENHAGEN,
+		TradableAreaIdEnum.COPENHAGEN,
 		new CityArea(
-			TradingAreaIdEnum.COPENHAGEN,
+			TradableAreaIdEnum.COPENHAGEN,
 			'코펜하겐',
 			'덴마크의 수도',
 			{
@@ -267,9 +267,9 @@ export const cityAreaMap: Map<TradingAreaIdEnum, CityArea> = new Map([
 		),
 	],
 	[
-		TradingAreaIdEnum.STOCKHOLM,
+		TradableAreaIdEnum.STOCKHOLM,
 		new CityArea(
-			TradingAreaIdEnum.STOCKHOLM,
+			TradableAreaIdEnum.STOCKHOLM,
 			'스톡홀름',
 			'스웨덴의 수도',
 			{
@@ -287,9 +287,9 @@ export const cityAreaMap: Map<TradingAreaIdEnum, CityArea> = new Map([
 		),
 	],
 	[
-		TradingAreaIdEnum.BERN,
+		TradableAreaIdEnum.BERN,
 		new CityArea(
-			TradingAreaIdEnum.BERN,
+			TradableAreaIdEnum.BERN,
 			'베른',
 			'스위스의 수도',
 			{
@@ -307,9 +307,9 @@ export const cityAreaMap: Map<TradingAreaIdEnum, CityArea> = new Map([
 		),
 	],
 	[
-		TradingAreaIdEnum.BERLIN,
+		TradableAreaIdEnum.BERLIN,
 		new CityArea(
-			TradingAreaIdEnum.BERLIN,
+			TradableAreaIdEnum.BERLIN,
 			'베를린',
 			'독일의 수도',
 			{
@@ -327,9 +327,9 @@ export const cityAreaMap: Map<TradingAreaIdEnum, CityArea> = new Map([
 		),
 	],
 	[
-		TradingAreaIdEnum.OTAWA,
+		TradableAreaIdEnum.OTAWA,
 		new CityArea(
-			TradingAreaIdEnum.OTAWA,
+			TradableAreaIdEnum.OTAWA,
 			'오타와',
 			'캐나다의 수도',
 			{
@@ -347,9 +347,9 @@ export const cityAreaMap: Map<TradingAreaIdEnum, CityArea> = new Map([
 		),
 	],
 	[
-		TradingAreaIdEnum.BUENOSAIRES,
+		TradableAreaIdEnum.BUENOSAIRES,
 		new CityArea(
-			TradingAreaIdEnum.BUENOSAIRES,
+			TradableAreaIdEnum.BUENOSAIRES,
 			'부에노스 아이레스',
 			'아르헨티나의 수도',
 			{
@@ -367,9 +367,9 @@ export const cityAreaMap: Map<TradingAreaIdEnum, CityArea> = new Map([
 		),
 	],
 	[
-		TradingAreaIdEnum.SAO_PAULO,
+		TradableAreaIdEnum.SAO_PAULO,
 		new CityArea(
-			TradingAreaIdEnum.SAO_PAULO,
+			TradableAreaIdEnum.SAO_PAULO,
 			'상파울로',
 			'브라질의 수도',
 			{
@@ -387,9 +387,9 @@ export const cityAreaMap: Map<TradingAreaIdEnum, CityArea> = new Map([
 		),
 	],
 	[
-		TradingAreaIdEnum.SYDNEY,
+		TradableAreaIdEnum.SYDNEY,
 		new CityArea(
-			TradingAreaIdEnum.SYDNEY,
+			TradableAreaIdEnum.SYDNEY,
 			'시드니',
 			'호주의 수도',
 			{
@@ -407,9 +407,9 @@ export const cityAreaMap: Map<TradingAreaIdEnum, CityArea> = new Map([
 		),
 	],
 	[
-		TradingAreaIdEnum.HAWAII,
+		TradableAreaIdEnum.HAWAII,
 		new CityArea(
-			TradingAreaIdEnum.HAWAII,
+			TradableAreaIdEnum.HAWAII,
 			'하와이',
 			'미국의 휴양지',
 			{
@@ -427,9 +427,9 @@ export const cityAreaMap: Map<TradingAreaIdEnum, CityArea> = new Map([
 		),
 	],
 	[
-		TradingAreaIdEnum.LISBON,
+		TradableAreaIdEnum.LISBON,
 		new CityArea(
-			TradingAreaIdEnum.LISBON,
+			TradableAreaIdEnum.LISBON,
 			'리스본',
 			'포르투갈의 수도',
 			{
@@ -447,9 +447,9 @@ export const cityAreaMap: Map<TradingAreaIdEnum, CityArea> = new Map([
 		),
 	],
 	[
-		TradingAreaIdEnum.MADRID,
+		TradableAreaIdEnum.MADRID,
 		new CityArea(
-			TradingAreaIdEnum.MADRID,
+			TradableAreaIdEnum.MADRID,
 			'마드리드',
 			'스페인의 수도',
 			{
@@ -467,9 +467,9 @@ export const cityAreaMap: Map<TradingAreaIdEnum, CityArea> = new Map([
 		),
 	],
 	[
-		TradingAreaIdEnum.TOKYO,
+		TradableAreaIdEnum.TOKYO,
 		new CityArea(
-			TradingAreaIdEnum.TOKYO,
+			TradableAreaIdEnum.TOKYO,
 			'도쿄',
 			'일본의 수도',
 			{
@@ -487,9 +487,9 @@ export const cityAreaMap: Map<TradingAreaIdEnum, CityArea> = new Map([
 		),
 	],
 	[
-		TradingAreaIdEnum.PARIS,
+		TradableAreaIdEnum.PARIS,
 		new CityArea(
-			TradingAreaIdEnum.PARIS,
+			TradableAreaIdEnum.PARIS,
 			'파리',
 			'프랑스의 수도',
 			{
@@ -507,9 +507,9 @@ export const cityAreaMap: Map<TradingAreaIdEnum, CityArea> = new Map([
 		),
 	],
 	[
-		TradingAreaIdEnum.ROME,
+		TradableAreaIdEnum.ROME,
 		new CityArea(
-			TradingAreaIdEnum.ROME,
+			TradableAreaIdEnum.ROME,
 			'로마',
 			'이탈리아의 수도',
 			{
@@ -527,9 +527,9 @@ export const cityAreaMap: Map<TradingAreaIdEnum, CityArea> = new Map([
 		),
 	],
 	[
-		TradingAreaIdEnum.LONDON,
+		TradableAreaIdEnum.LONDON,
 		new CityArea(
-			TradingAreaIdEnum.LONDON,
+			TradableAreaIdEnum.LONDON,
 			'런던',
 			'영국의 수도',
 			{
@@ -547,9 +547,9 @@ export const cityAreaMap: Map<TradingAreaIdEnum, CityArea> = new Map([
 		),
 	],
 	[
-		TradingAreaIdEnum.NEW_YORK,
+		TradableAreaIdEnum.NEW_YORK,
 		new CityArea(
-			TradingAreaIdEnum.NEW_YORK,
+			TradableAreaIdEnum.NEW_YORK,
 			'뉴욕',
 			'미국 최대의 도시',
 			{
@@ -568,11 +568,11 @@ export const cityAreaMap: Map<TradingAreaIdEnum, CityArea> = new Map([
 	],
 ]);
 
-export const specialAreaMap: Map<TradingAreaIdEnum, SpecialArea> = new Map([
+export const specialAreaMap: Map<TradableAreaIdEnum, SpecialArea> = new Map([
 	[
-		TradingAreaIdEnum.JEJU_ISLAND,
+		TradableAreaIdEnum.JEJU_ISLAND,
 		new SpecialArea(
-			TradingAreaIdEnum.JEJU_ISLAND,
+			TradableAreaIdEnum.JEJU_ISLAND,
 			'제주',
 			'대한민국의 휴양지',
 			200000,
@@ -580,9 +580,9 @@ export const specialAreaMap: Map<TradingAreaIdEnum, SpecialArea> = new Map([
 		),
 	],
 	[
-		TradingAreaIdEnum.CONCORDE,
+		TradableAreaIdEnum.CONCORDE,
 		new SpecialArea(
-			TradingAreaIdEnum.CONCORDE,
+			TradableAreaIdEnum.CONCORDE,
 			'콩코드여객기',
 			'초음속여객기',
 			200000,
@@ -590,9 +590,9 @@ export const specialAreaMap: Map<TradingAreaIdEnum, SpecialArea> = new Map([
 		),
 	],
 	[
-		TradingAreaIdEnum.BUSAN,
+		TradableAreaIdEnum.BUSAN,
 		new SpecialArea(
-			TradingAreaIdEnum.BUSAN,
+			TradableAreaIdEnum.BUSAN,
 			'부산',
 			'대한민국의 제1의 항구도시',
 			500000,
@@ -600,9 +600,9 @@ export const specialAreaMap: Map<TradingAreaIdEnum, SpecialArea> = new Map([
 		),
 	],
 	[
-		TradingAreaIdEnum.QUEEN_ELIZABETH,
+		TradableAreaIdEnum.QUEEN_ELIZABETH,
 		new SpecialArea(
-			TradingAreaIdEnum.QUEEN_ELIZABETH,
+			TradableAreaIdEnum.QUEEN_ELIZABETH,
 			'퀸 엘리자베스호',
 			'호화 여객선',
 			300000,
@@ -610,9 +610,9 @@ export const specialAreaMap: Map<TradingAreaIdEnum, SpecialArea> = new Map([
 		),
 	],
 	[
-		TradingAreaIdEnum.COLUMBIA,
+		TradableAreaIdEnum.COLUMBIA,
 		new SpecialArea(
-			TradingAreaIdEnum.COLUMBIA,
+			TradableAreaIdEnum.COLUMBIA,
 			'컬럼비아호',
 			'유인 우주 왕복선',
 			450000,
@@ -620,9 +620,9 @@ export const specialAreaMap: Map<TradingAreaIdEnum, SpecialArea> = new Map([
 		),
 	],
 	[
-		TradingAreaIdEnum.SEOUL,
+		TradableAreaIdEnum.SEOUL,
 		new SpecialArea(
-			TradingAreaIdEnum.SEOUL,
+			TradableAreaIdEnum.SEOUL,
 			'서울',
 			'대한민국의 수도',
 			1000000,
@@ -634,50 +634,50 @@ export const specialAreaMap: Map<TradingAreaIdEnum, SpecialArea> = new Map([
 export const boardMatrix: BaseTile[][] = [
 	[
 		new BaseTile(TileType.STARTING_POINT),
-		cityAreaMap.get(TradingAreaIdEnum.TAIPEI) as CityArea,
+		cityAreaMap.get(TradableAreaIdEnum.TAIPEI) as CityArea,
 		new GoldenKey(1),
-		cityAreaMap.get(TradingAreaIdEnum.BEIJING) as CityArea,
-		cityAreaMap.get(TradingAreaIdEnum.MANILA) as CityArea,
-		specialAreaMap.get(TradingAreaIdEnum.JEJU_ISLAND) as SpecialArea,
-		cityAreaMap.get(TradingAreaIdEnum.SINGAPORE) as CityArea,
+		cityAreaMap.get(TradableAreaIdEnum.BEIJING) as CityArea,
+		cityAreaMap.get(TradableAreaIdEnum.MANILA) as CityArea,
+		specialAreaMap.get(TradableAreaIdEnum.JEJU_ISLAND) as SpecialArea,
+		cityAreaMap.get(TradableAreaIdEnum.SINGAPORE) as CityArea,
 		new GoldenKey(2),
-		cityAreaMap.get(TradingAreaIdEnum.CAIRO) as CityArea,
-		cityAreaMap.get(TradingAreaIdEnum.ISTANBUL) as CityArea,
+		cityAreaMap.get(TradableAreaIdEnum.CAIRO) as CityArea,
+		cityAreaMap.get(TradableAreaIdEnum.ISTANBUL) as CityArea,
 	],
 	[
 		new BaseTile(TileType.DESERT_ISLAND),
-		cityAreaMap.get(TradingAreaIdEnum.ATHENES) as CityArea,
+		cityAreaMap.get(TradableAreaIdEnum.ATHENES) as CityArea,
 		new GoldenKey(3),
-		cityAreaMap.get(TradingAreaIdEnum.COPENHAGEN) as CityArea,
-		cityAreaMap.get(TradingAreaIdEnum.STOCKHOLM) as CityArea,
-		specialAreaMap.get(TradingAreaIdEnum.CONCORDE) as SpecialArea,
-		cityAreaMap.get(TradingAreaIdEnum.BERN) as CityArea,
+		cityAreaMap.get(TradableAreaIdEnum.COPENHAGEN) as CityArea,
+		cityAreaMap.get(TradableAreaIdEnum.STOCKHOLM) as CityArea,
+		specialAreaMap.get(TradableAreaIdEnum.CONCORDE) as SpecialArea,
+		cityAreaMap.get(TradableAreaIdEnum.BERN) as CityArea,
 		new GoldenKey(4),
-		cityAreaMap.get(TradingAreaIdEnum.BERLIN) as CityArea,
-		cityAreaMap.get(TradingAreaIdEnum.OTAWA) as CityArea,
+		cityAreaMap.get(TradableAreaIdEnum.BERLIN) as CityArea,
+		cityAreaMap.get(TradableAreaIdEnum.OTAWA) as CityArea,
 	],
 	[
 		new BaseTile(TileType.GET_WELFARE),
-		cityAreaMap.get(TradingAreaIdEnum.BUENOSAIRES) as CityArea,
+		cityAreaMap.get(TradableAreaIdEnum.BUENOSAIRES) as CityArea,
 		new GoldenKey(5),
-		cityAreaMap.get(TradingAreaIdEnum.SAO_PAULO) as CityArea,
-		cityAreaMap.get(TradingAreaIdEnum.SYDNEY) as CityArea,
-		specialAreaMap.get(TradingAreaIdEnum.BUSAN) as SpecialArea,
-		cityAreaMap.get(TradingAreaIdEnum.HAWAII) as CityArea,
-		cityAreaMap.get(TradingAreaIdEnum.LISBON) as CityArea,
-		specialAreaMap.get(TradingAreaIdEnum.QUEEN_ELIZABETH) as SpecialArea,
-		cityAreaMap.get(TradingAreaIdEnum.MADRID) as CityArea,
+		cityAreaMap.get(TradableAreaIdEnum.SAO_PAULO) as CityArea,
+		cityAreaMap.get(TradableAreaIdEnum.SYDNEY) as CityArea,
+		specialAreaMap.get(TradableAreaIdEnum.BUSAN) as SpecialArea,
+		cityAreaMap.get(TradableAreaIdEnum.HAWAII) as CityArea,
+		cityAreaMap.get(TradableAreaIdEnum.LISBON) as CityArea,
+		specialAreaMap.get(TradableAreaIdEnum.QUEEN_ELIZABETH) as SpecialArea,
+		cityAreaMap.get(TradableAreaIdEnum.MADRID) as CityArea,
 	],
 	[
 		new BaseTile(TileType.SPACE_TRAVEL),
-		cityAreaMap.get(TradingAreaIdEnum.TOKYO) as CityArea,
-		specialAreaMap.get(TradingAreaIdEnum.COLUMBIA) as SpecialArea,
-		cityAreaMap.get(TradingAreaIdEnum.PARIS) as CityArea,
-		cityAreaMap.get(TradingAreaIdEnum.ROME) as CityArea,
+		cityAreaMap.get(TradableAreaIdEnum.TOKYO) as CityArea,
+		specialAreaMap.get(TradableAreaIdEnum.COLUMBIA) as SpecialArea,
+		cityAreaMap.get(TradableAreaIdEnum.PARIS) as CityArea,
+		cityAreaMap.get(TradableAreaIdEnum.ROME) as CityArea,
 		new GoldenKey(6),
-		cityAreaMap.get(TradingAreaIdEnum.LONDON) as CityArea,
-		cityAreaMap.get(TradingAreaIdEnum.NEW_YORK) as CityArea,
+		cityAreaMap.get(TradableAreaIdEnum.LONDON) as CityArea,
+		cityAreaMap.get(TradableAreaIdEnum.NEW_YORK) as CityArea,
 		new BaseTile(TileType.GET_WELFARE),
-		specialAreaMap.get(TradingAreaIdEnum.SEOUL) as SpecialArea,
+		specialAreaMap.get(TradableAreaIdEnum.SEOUL) as SpecialArea,
 	],
 ];

--- a/src/shared/boardData.ts
+++ b/src/shared/boardData.ts
@@ -30,7 +30,7 @@ export class TradableArea extends BaseTile {
 	}
 
 	get englishName() {
-		return TradableAreaIdEnum[this.id].replace('_', ' ');
+		return this.id as string;
 	}
 }
 
@@ -59,35 +59,35 @@ export class SpecialArea extends TradableArea {
 }
 
 export enum TradableAreaIdEnum {
-	TAIPEI,
-	BEIJING,
-	MANILA,
-	JEJU_ISLAND,
-	SINGAPORE,
-	CAIRO,
-	ISTANBUL,
-	ATHENES,
-	COPENHAGEN,
-	STOCKHOLM,
-	CONCORDE,
-	BERN,
-	BERLIN,
-	OTAWA,
-	BUENOSAIRES,
-	SAO_PAULO,
-	SYDNEY,
-	BUSAN,
-	HAWAII,
-	LISBON,
-	QUEEN_ELIZABETH,
-	MADRID,
-	TOKYO,
-	COLUMBIA,
-	PARIS,
-	ROME,
-	LONDON,
-	NEW_YORK,
-	SEOUL,
+	TAIPEI = 'TAIPEI',
+	BEIJING = 'BEIJING',
+	MANILA = 'MANILA',
+	JEJU_ISLAND = 'JEJU ISLAND',
+	SINGAPORE = 'SINGAPORE',
+	CAIRO = 'CAIRO',
+	ISTANBUL = 'ISTANBUL',
+	ATHENES = 'ATHENES',
+	COPENHAGEN = 'COPENHAGEN',
+	STOCKHOLM = 'STOCKHOLM',
+	CONCORDE = 'CONCORDE',
+	BERN = 'BERN',
+	BERLIN = 'BERLIN',
+	OTAWA = 'OTAWA',
+	BUENOSAIRES = 'BUENOSAIRES',
+	SAO_PAULO = 'SAO PAULO',
+	SYDNEY = 'SYDNEY',
+	BUSAN = 'BUSAN',
+	HAWAII = 'HAWAII',
+	LISBON = 'LISBON',
+	QUEEN_ELIZABETH = 'QUEEN ELIZABETH',
+	MADRID = 'MADRID',
+	TOKYO = 'TOKYO',
+	COLUMBIA = 'COLUMBIA',
+	PARIS = 'PARIS',
+	ROME = 'ROME',
+	LONDON = 'LONDON',
+	NEW_YORK = 'NEW YORK',
+	SEOUL = 'SEOUL',
 }
 
 export interface PriceInfo {
@@ -96,9 +96,6 @@ export interface PriceInfo {
 	buildingPrice: number;
 	hotelPrice: number;
 }
-
-export const getTradableAreaEnglishName = (areaId: TradableAreaIdEnum) =>
-	TradableAreaIdEnum[areaId].replace('_', ' ');
 
 export const cityAreaMap: Map<TradableAreaIdEnum, CityArea> = new Map([
 	[

--- a/src/shared/boardData.ts
+++ b/src/shared/boardData.ts
@@ -35,19 +35,14 @@ export class TradableArea extends BaseTile {
 }
 
 export class CityArea extends TradableArea {
-	buildingPriceInfo: PriceInfo;
-	paymentInfo: PriceInfo;
-
 	constructor(
 		id: TradableAreaIdEnum,
 		name: string,
 		description: string,
-		buildingPriceInfo: PriceInfo,
-		paymentInfo: PriceInfo,
+		public buildingPriceInfo: PriceInfo,
+		public paymentInfo: PriceInfo,
 	) {
 		super(TileType.CITY, id, name, description);
-		this.buildingPriceInfo = buildingPriceInfo;
-		this.paymentInfo = paymentInfo;
 	}
 }
 

--- a/src/shared/boardData.ts
+++ b/src/shared/boardData.ts
@@ -1,6 +1,6 @@
 export enum TileType {
 	STARTING_POINT,
-	COUNTRY,
+	CITY,
 	SPECIAL_AREA,
 	GOLDEN_KEY,
 	DESERT_ISLAND,
@@ -21,7 +21,7 @@ export class GoldenKey extends BaseTile {
 
 export class TradableArea extends BaseTile {
 	constructor(
-		type: TileType.COUNTRY | TileType.SPECIAL_AREA,
+		type: TileType.CITY | TileType.SPECIAL_AREA,
 		public id: TradableAreaIdEnum,
 		public name: string,
 		public description: string,
@@ -45,7 +45,7 @@ export class CityArea extends TradableArea {
 		buildingPriceInfo: PriceInfo,
 		paymentInfo: PriceInfo,
 	) {
-		super(TileType.COUNTRY, id, name, description);
+		super(TileType.CITY, id, name, description);
 		this.buildingPriceInfo = buildingPriceInfo;
 		this.paymentInfo = paymentInfo;
 	}

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,0 +1,3 @@
+import * as boardData from './boardData';
+
+export { boardData };


### PR DESCRIPTION
부루마블의 보드 칸에 대한 데이터를 정의한 boardData를 추가했습니다.
## 관련 class
- BaseArea: 모든 보드 칸에 대한 객체
- GoldenKey: 황금 열쇠 보드 칸에 대한 객체
- TradingArea: 특수 지역, 일반 지역 보드 칸에 대한 객체
- CityArea: 일반 지역 보드 칸에 대한 객체
- SpecialArea: 특수 지역 보드 칸에 대한 객체

## 관련 enum
- AreaType: 보드 칸의 타입을 정의한 enum
- TradingAreaIdEnum: TradingArea를 구분하기 위한 id를 저장한 enum