### PR TITLE
eslint rule 수정

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,7 +20,11 @@ module.exports = {
 			VariableDeclarator: 1,
 		}],
 		'import/extensions': 'off',
-		'import/prefer-default-export': 'off'
+		'import/prefer-default-export': 'off',
+		'import/no-unresolved': 'off',
+		'max-classes-per-file': 'off',
+		'no-useless-constructor': 'off',
+		'@typescript-eslint/no-useless-constructor': 'error',
 	},
 	overrides: [
 		{

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,9 @@ module.exports = {
 		'max-classes-per-file': 'off',
 		'no-useless-constructor': 'off',
 		'@typescript-eslint/no-useless-constructor': 'error',
+		'no-plusplus': ['error', {
+			allowForLoopAfterthoughts: true,
+		}],
 	},
 	overrides: [
 		{


### PR DESCRIPTION
eslint 규칙을 수정했습니다.
- `no-useless-constructor`를 `@typescript-eslint/no-useless-constructor`로 대체
- `import/prefer-default-export`, `import/no-unresolved`, `max-classes-per-file` 비활성화