### PR TITLE
마이너한 이슈와, 주사위 이동 전 토지 팔기 기능

### DIFF
--- a/src/components/game-interface/before-user-command.vue
+++ b/src/components/game-interface/before-user-command.vue
@@ -10,7 +10,7 @@
 	<p v-if="currentTurnUserIsBindedDesertIsland">
 		현재 무인도에 갇힌 상태입니다. 더블이 나오거나 {{ bindingTurnCountOnDesert }} 턴 뒤에 나올 수 있습니다.
 	</p>
-	<button @click="$emit('trade-with-bank')">내 토지 팔기</button>
+	<button v-if="isUserHasTile" @click="$emit('trade-with-bank')">내 토지 팔기</button>
 	<button @click="rollDice">주사위 굴리기(즉시 실행됩니다.)</button>
 </template>
 
@@ -32,6 +32,7 @@ const useDiceData = () => {
 	} = toRefs(gameInterface);
 
 	return {
+		isUserHasTile: computed(() => gameInterface.bank.checkUserHasTile(gameInterface.currentTurnUser.id)),
 		hasDiceResult: computed(() => currentTurnDiceResult.value.length > 0),
 		currentTurnDiceResult: computed(() => currentTurnDiceResult.value),
 		isDouble: computed(() => getters['gameInterface/isDouble']),

--- a/src/components/game-interface/trade-with-bank.vue
+++ b/src/components/game-interface/trade-with-bank.vue
@@ -1,5 +1,6 @@
 <template>
 	<p>은행과 거래할 항목을 선택하세요.</p>
+	<p>{{currentTurnUser}}유저의 잔액은{{ currentTurnUsersRemainedMoney }}원 입니다.</p>
 	<button v-if="!isTileBelongToUser && selectedTile" @click="changeBankState(BankState.BUY_TILE)">토지 사기</button>
 	<button v-if="isTileBelongToUser || isUserHasTile" @click="changeBankState(BankState.SELL_TILES)">토지 팔기</button>
 	<button v-if="isTileBelongToUser && !isUserHasTileProperties && selectedTile" @click="changeBankState(BankState.BUY_PROPERTIES)">건물 사기</button>
@@ -136,6 +137,8 @@ export default defineComponent({
 			propertyType,
 			currentBankState,
 			checkedProperties,
+			currentTurnUser: computed(() => gameInterface.currentTurnUser.id),
+			currentTurnUsersRemainedMoney: computed(() => formatMoney(gameInterface.currentTurnUser.getMoney())),
 			purchasedPropertiesOnSelectedTile: computed(() => gameInterface.bank.getPurchasedProperties(gameInterface.selectedTile)),
 			selectedTile: computed(() => gameInterface.selectedTile),
 			tilePrice: computed(() => formatMoney(gameInterface.bank.getTilePrice(gameInterface.selectedTile))),

--- a/src/shared/Bank.ts
+++ b/src/shared/Bank.ts
@@ -1,7 +1,7 @@
 import {tileMatrix, CityTile, TouristAttractionTile, TradableTile} from '@/shared/boardData';
 import {propertyType} from '@/shared/policy';
 
-interface Tiles {
+export interface Tiles {
 	tile: TradableTile;
 	owner: null | number;
 	properties: {
@@ -113,6 +113,7 @@ export class Bank {
 
 	getTilePrice(tile: TradableTile): number {
 		const selectedTile = this.allTiles.find((t) => t.tile.id === tile.id);
+		console.info(selectedTile);
 		if (!selectedTile) return 0;
 		if (selectedTile.tile instanceof TouristAttractionTile) {
 			return selectedTile.tile.price;
@@ -214,5 +215,21 @@ export class Bank {
 	checkUserHasProperties(id: number): boolean {
 		const isUserHasTile = this.checkUserHasTile(id);
 		return isUserHasTile && this.allTiles.some((t) => t.properties.HOTEL + t.properties.BUILDING + t.properties.VILLA > 0);
+	}
+
+	getUsersTile(id: number): Tiles[] {
+		return this.allTiles.filter((t) => t.owner === id);
+	}
+
+	getUsersTileAndProperties(tile: TradableTile, id: number): propertyType[] {
+		const selectedTile = this.allTiles.find((t) => t.tile.id === tile.id);
+		if (selectedTile) {
+			if (selectedTile.owner === id) {
+				const keys = Object.keys(selectedTile.properties) as propertyType[];
+				return keys.filter((key) => selectedTile.properties[key] > 0);
+			}
+			return [];
+		}
+		return [];
 	}
 }

--- a/src/views/game-interface.vue
+++ b/src/views/game-interface.vue
@@ -7,7 +7,7 @@
 			<before-user-command @trade-with-bank="changeState(GameState.TRADE_WITH_BANK)" />
 		</template>
 		<template v-else-if="currentState === GameState.TRADE_WITH_BANK">
-			<trade-with-bank @end-trade="nextTurn(GameState.BEFORE_USER_COMMAND)"/>
+			<trade-with-bank @end-trade="changeState(GameState.BEFORE_USER_COMMAND)"/>
 		</template>
 		<template v-else-if="currentState === GameState.USER_MOVED">
 			<trade-with-bank @end-trade="nextTurn(GameState.BEFORE_USER_COMMAND)"/>
@@ -98,7 +98,7 @@ const useChangeStateAfterUserCommand = () => {
 			(currentTurnUser.value as User).bindOnDesertIsland();
 			nextTurn(GameState.BEFORE_USER_COMMAND);
 		} else if (tileTypesToTrade.includes(arrivedTileType)) {
-			changeState(GameState.TRADE_WITH_BANK);
+			// changeState(GameState.TRADE_WITH_BANK);
 		} else if (arrivedTileType === TileType.GOLDEN_KEY) {
 			// TODO: 추후에 추가
 		} else if (arrivedTileType === TileType.GET_WELFARE) {


### PR DESCRIPTION
추후 해결이 필요한 부분이 있어 이슈로 생성 해둡니다. (#14 )

- 주사위를 굴리기 전 은행 진입 후 거래 종료를 하면 여전히 해당 턴의 유저에게 턴이 돌아가게 합니다.
- 주사위 이동 전 은행과의 거래를 통해 토지를 매각할 수 있습니다.